### PR TITLE
use v5 api instead of unsupported v4

### DIFF
--- a/ddb-live-campaign.user.js
+++ b/ddb-live-campaign.user.js
@@ -2,7 +2,7 @@
 // @name			D&D Beyond Live-Update Campaign
 // @namespace		https://github.com/FaithLilley/DnDBeyond-Live-Campaign/
 // @copyright		Copyright (c) 2024 Faith Elisabeth Lilley (aka Stormknight)
-// @version			1.0
+// @version			1.1
 // @description		Provides live character data on the D&D Beyond campaign page
 // @author			Faith Elisabeth Lilley (aka Stormknight)
 // @match			https://www.dndbeyond.com/campaigns/*
@@ -24,13 +24,13 @@ console.log("Initialising D&D Beyond Live Campaign script.");
 
 // jQuery set-up
 const rulesUrls = [
-  "https://character-service.dndbeyond.com/character/v4/rule-data",
+  "https://character-service.dndbeyond.com/character/v5/rule-data",
   "https://gamedata-service.dndbeyond.com/vehicles/v3/rule-data",
 ];
 const charJSONurlBase =
-  "https://character-service.dndbeyond.com/character/v4/character/";
+  "https://character-service.dndbeyond.com/character/v5/character/";
 const gameCollectionUrl = {
-  prefix: "https://character-service.dndbeyond.com/character/v4/game-data/",
+  prefix: "https://character-service.dndbeyond.com/character/v5/game-data/",
   postfix: "/collection",
 };
 const optionalRules = {


### PR DESCRIPTION
https://character-service.dndbeyond.com/character/v4/rule-data AND 
https://character-service.dndbeyond.com/character/v4/character/* both return: 
`{
    "id": 0,
    "success": false,
    "message": "The requested API version is no longer supported.",
    "data": null,
    "pagination": null
}`

Resulting in 
![image](https://github.com/FaithLilley/DnDBeyond-Live-Campaign/assets/23217607/c742adbf-e7c5-4f0f-bb5b-fc137da08fce)


DnDBeyond no longer supports the v4 api for rule-data or characters, switch to using v5 api. 
AFAIK the schema has not changed.
Updated version to 1.1